### PR TITLE
Fix errors and warnings in kube-burner output (#3)

### DIFF
--- a/config/scripts/check.sh
+++ b/config/scripts/check.sh
@@ -179,7 +179,7 @@ check_vm_shutdown() {
     
     # Check if VMs are in Stopped state
     local total_vms=$(oc get vm -n "${namespace}" -l "${label_key}=${label_value}" --no-headers | wc -l)
-    local stopped_vms=$(oc get vm -n "${namespace}" -l "${label_key}=${label_value}" -o jsonpath='{.items[?(@.spec.running==false)].metadata.name}' | wc -w)
+    local stopped_vms=$(oc get vm -n "${namespace}" -l "${label_key}=${label_value}" -o jsonpath='{.items[?(@.spec.runStrategy=="Halted")].metadata.name}' | wc -w)
     
     echo "Total VMs: ${total_vms}, Stopped VMs: ${stopped_vms}"
     

--- a/hot-plug/disk-hotplug/templates/vm.yaml
+++ b/hot-plug/disk-hotplug/templates/vm.yaml
@@ -9,7 +9,7 @@ metadata:
 {{- end }}
   name: '{{.name}}-{{.Replica}}'
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/performance/high-memory/vm-high-memory.yml
+++ b/performance/high-memory/vm-high-memory.yml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   name: {{.name}}-{{.Replica}}
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/performance/large-disk/vm-large-disk.yml
+++ b/performance/large-disk/vm-large-disk.yml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   name: {{.name}}-{{.Replica}}
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/performance/minimal-resources/vm-minimal-resources.yml
+++ b/performance/minimal-resources/vm-minimal-resources.yml
@@ -9,7 +9,7 @@ metadata:
   {{end}}
   name: {{.name}}-{{.Replica}}
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/resource-limits/cpu-limits/vm-cpu-template.yml
+++ b/resource-limits/cpu-limits/vm-cpu-template.yml
@@ -9,7 +9,7 @@ metadata:
 {{- end }}
   name: {{.name}}-{{.Replica}}
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/resource-limits/disk-limits/vm-disk-template.yml
+++ b/resource-limits/disk-limits/vm-disk-template.yml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   name: {{.name}}-{{.Replica}}
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/resource-limits/memory-limits/vm-memory-template.yml
+++ b/resource-limits/memory-limits/vm-memory-template.yml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   name: {{.name}}-{{.Replica}}
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/scale-testing/per-host-density/config/scripts/check.sh
+++ b/scale-testing/per-host-density/config/scripts/check.sh
@@ -383,7 +383,7 @@ function check_vm_shutdown() {
     # Shutdown State Check
     local shutdown_check_start=$(date +%s)
     local stopped_vms
-    stopped_vms=$(oc get vm ${ns_flag} -l "${label_key}=${label_value}" -o jsonpath='{.items[?(@.spec.running==false)].metadata.name}' | wc -w)
+    stopped_vms=$(oc get vm ${ns_flag} -l "${label_key}=${label_value}" -o jsonpath='{.items[?(@.spec.runStrategy=="Halted")].metadata.name}' | wc -w)
     local shutdown_check_duration=$(( $(date +%s) - shutdown_check_start ))
     
     echo "Stopped VMs: ${stopped_vms}/${total_vms}"

--- a/scale-testing/per-host-density/per-host-density.yml
+++ b/scale-testing/per-host-density/per-host-density.yml
@@ -20,11 +20,6 @@
 {{- $namespacePrefix := .testNamespacePrefix | default "per-host-density-test" -}}
 {{- $nsName := $namespacePrefix -}}
 ---
-global:
-  measurements:
-  - name: vmiLatency
-  - name: pvcLatency
-
 metricsEndpoints:
 - indexer:
     type: local
@@ -90,6 +85,10 @@ jobs:
   objects:
   - objectTemplate: source-datavolume.yml
     replicas: 1
+    waitOptions:
+      customStatusPaths:
+      - key: '.status.phase'
+        value: 'Succeeded'
     inputVars:
       name: per-host-source
       storage: {{ $sourceStorageSizeStr }}
@@ -100,6 +99,9 @@ jobs:
 # Create VMs - supports single-node or multi-node distribution
 - name: create-vms
   jobType: create
+  measurements:
+  - name: vmiLatency
+  - name: pvcLatency
   jobIterations: {{ $namespaceCount }}
   qps: {{ .qpsCreate }}
   burst: {{ .burstCreate }}

--- a/scale-testing/per-host-density/vm-per-host-template.yml
+++ b/scale-testing/per-host-density/vm-per-host-template.yml
@@ -13,7 +13,7 @@ metadata:
   {{end}}
   name: "{{.name}}-{{.counter}}-{{.Replica}}"
 spec:
-  running: {{.VMIrunning}}
+  runStrategy: {{ if .VMIrunning }}Always{{ else }}Halted{{ end }}
   template:
     metadata:
       labels:

--- a/scale-testing/virt-capacity-benchmark/templates/vm.yml
+++ b/scale-testing/virt-capacity-benchmark/templates/vm.yml
@@ -51,7 +51,7 @@ spec:
           requests:
             storage: {{ $dataVolumeSize }}
   {{ end }}
-  running: true
+  runStrategy: Always
   template:
     spec:
       accessCredentials:

--- a/scale-testing/virt-capacity-benchmark/virt-capacity-benchmark.yml
+++ b/scale-testing/virt-capacity-benchmark/virt-capacity-benchmark.yml
@@ -206,7 +206,7 @@ jobs:
         {{ $jobCounterLabelKey }}: {{ $jobCounterLabelValue }}
     waitOptions:
       customStatusPaths:
-      - key: '(.conditions.[] | select(.type == "Ready")).status'
+      - key: '((.conditions // [])[] | select(.type == "Ready")).status'
         value: "True"
       labelSelector:
         {{ $jobCounterLabelKey }}: {{ $jobCounterLabelValue }}


### PR DESCRIPTION
- Replace deprecated spec.running with spec.runStrategy across all VM templates (9 files) and check scripts (2 files). Uses runStrategy: Always/Halted instead of running: true/false.
- Make jq waitOptions path null-safe in virt-capacity-benchmark snapshot job by defaulting conditions to empty array: ((.conditions // [])[]...)
- Move vmiLatency/pvcLatency from global measurements to create-vms job only in per-host-density, preventing "Empty document list" errors on non-VM jobs (create-ssh-secret, create-source-dv).
- Add explicit waitOptions with status.phase=Succeeded for DataVolume in per-host-density create-source-dv job.

Closes #3