### PR TITLE
Fix per-host-density kube-burner 1.15.0 compatibility

### DIFF
--- a/scale-testing/per-host-density/per-host-density.yml
+++ b/scale-testing/per-host-density/per-host-density.yml
@@ -34,6 +34,11 @@ metricsEndpoints:
     esServers: [{{ .esServer }}]
     insecureSkipVerify: true
 {{- end }}
+global:
+  measurements:
+  - name: vmiLatency
+  - name: pvcLatency
+
 jobs:
 # Run cleanup only when counter is 0
 {{ if eq (.counter | int) 0 }}
@@ -82,13 +87,11 @@ jobs:
   maxWaitTimeout: {{ .maxWaitTimeout }}
   jobPause: {{ .jobPause }}
   cleanup: false
+  waitWhenFinished: true
+  podWait: true
   objects:
   - objectTemplate: source-datavolume.yml
     replicas: 1
-    waitOptions:
-      customStatusPaths:
-      - key: '.status.phase'
-        value: 'Succeeded'
     inputVars:
       name: per-host-source
       storage: {{ $sourceStorageSizeStr }}
@@ -99,9 +102,6 @@ jobs:
 # Create VMs - supports single-node or multi-node distribution
 - name: create-vms
   jobType: create
-  measurements:
-  - name: vmiLatency
-  - name: pvcLatency
   jobIterations: {{ $namespaceCount }}
   qps: {{ .qpsCreate }}
   burst: {{ .burstCreate }}


### PR DESCRIPTION
## Summary

Fixes kube-burner 1.15.0 compatibility issues in per-host-density that were introduced in PR #23:

- **Move measurements to global level**: kube-burner 1.15.0 does not support per-job `measurements` — having them on the `create-vms` job causes a fatal `field measurements not found in type config.rawJob` error. Moves `vmiLatency` and `pvcLatency` back to the `global:` section.
- **Fix DataVolume wait strategy**: `customStatusPaths` with `.status.phase == Succeeded` fails with `Error extracting or find status in object DataVolume` on kube-burner 1.15.0. Replaces it with `waitWhenFinished: true` + `podWait: true` so kube-burner waits for the CDI importer pod to complete.

The other fixes from PR #23 (runStrategy, check.sh) remain intact.

## Test plan

- [x] Ran per-host-density sanity mode successfully after applying these fixes on the jump host
- [ ] Verify full per-host-density run completes without errors