### PR TITLE
nic-hotplug: simplify NNCP label selectors in check.sh

### DIFF
--- a/config/scripts/check.sh
+++ b/config/scripts/check.sh
@@ -1136,45 +1136,26 @@ check_nic_hotplug() {
     local private_key="${5:-}"
     local vm_user="${6:-}"
     local validate_guest_os="${7:-true}"
-    local arg8="${8:-}"
-    local arg9="${9:-}"
-    local results_dir
-    local nncp_run_id=""
-    if [[ -n "${arg9}" ]]; then
-        nncp_run_id="${arg8}"
-        results_dir="${arg9}"
-    else
-        results_dir="${arg8:-/tmp/kube-burner-validations}"
-    fi
-
-    local nncp_simple_lbl="test-type=nic-hotplug-simple"
-    local nncp_vlan_lbl="test-type=nic-hotplug-vlan"
-    if [[ -n "${nncp_run_id}" ]]; then
-        nncp_simple_lbl="test-type=nic-hotplug-simple,cnv-scenarios.io/run=${nncp_run_id}"
-        nncp_vlan_lbl="test-type=nic-hotplug-vlan,cnv-scenarios.io/run=${nncp_run_id}"
-    fi
-
+    local results_dir="${8:-/tmp/kube-burner-validations}"
+    
     echo "=========================================="
     echo "NIC Hot-plug Validation"
     echo "=========================================="
     echo "Namespace: ${namespace}"
     echo "Expected NICs: ${expected_nic_count}"
     echo "Validate Guest OS: ${validate_guest_os}"
-    if [[ -n "${nncp_run_id}" ]]; then
-        echo "NNCP run scope: cnv-scenarios.io/run=${nncp_run_id}"
-    fi
     echo ""
     
     # 1. Validate NodeNetworkConfigurationPolicies (NNCPs)
     echo "[1/5] Validating NodeNetworkConfigurationPolicies..."
     
     local nncp_simple_count
-    nncp_simple_count=$(oc get nncp -l "${nncp_simple_lbl}" --no-headers 2>/dev/null | wc -l 2>/dev/null || echo "0")
+    nncp_simple_count=$(oc get nncp -l test-type=nic-hotplug-simple --no-headers 2>/dev/null | wc -l 2>/dev/null || echo "0")
     nncp_simple_count=$(echo "${nncp_simple_count}" | head -1 | tr -cd '0-9')
     nncp_simple_count=${nncp_simple_count:-0}
     
     local nncp_vlan_count
-    nncp_vlan_count=$(oc get nncp -l "${nncp_vlan_lbl}" --no-headers 2>/dev/null | wc -l 2>/dev/null || echo "0")
+    nncp_vlan_count=$(oc get nncp -l test-type=nic-hotplug-vlan --no-headers 2>/dev/null | wc -l 2>/dev/null || echo "0")
     nncp_vlan_count=$(echo "${nncp_vlan_count}" | head -1 | tr -cd '0-9')
     nncp_vlan_count=${nncp_vlan_count:-0}
     
@@ -1191,10 +1172,10 @@ check_nic_hotplug() {
     # Check NNCP status (Available condition)
     # Query both simple and vlan NNCPs separately since regex selector is not supported
     local nncp_ready_count
-    nncp_ready_count=$(oc get nncp -l "${nncp_simple_lbl}" -o json 2>/dev/null | \
+    nncp_ready_count=$(oc get nncp -l test-type=nic-hotplug-simple -o json 2>/dev/null | \
         jq '[.items[] | select(.status.conditions[]? | select(.type=="Available" and .status=="True"))] | length' 2>/dev/null || echo "0")
     local nncp_vlan_ready_count
-    nncp_vlan_ready_count=$(oc get nncp -l "${nncp_vlan_lbl}" -o json 2>/dev/null | \
+    nncp_vlan_ready_count=$(oc get nncp -l test-type=nic-hotplug-vlan -o json 2>/dev/null | \
         jq '[.items[] | select(.status.conditions[]? | select(.type=="Available" and .status=="True"))] | length' 2>/dev/null || echo "0")
     # Sanitize and sum
     nncp_ready_count=$(echo "${nncp_ready_count}" | head -1 | tr -cd '0-9')
@@ -1209,8 +1190,8 @@ check_nic_hotplug() {
     if [ "${nncp_ready_count}" -ne "${total_nncp_count}" ]; then
         echo "  ERROR: Not all NNCPs are in Ready state"
         echo "  Degraded NNCPs:"
-        oc get nncp -l "${nncp_simple_lbl}"
-        oc get nncp -l "${nncp_vlan_lbl}"
+        oc get nncp -l test-type=nic-hotplug-simple
+        oc get nncp -l test-type=nic-hotplug-vlan
         log_validation_checkpoint "nncp_status" "FAIL" "Only ${nncp_ready_count}/${total_nncp_count} NNCPs Ready"
         return 1
     fi

--- a/hot-plug/nic-hotplug/nic-hotplug-test.yml
+++ b/hot-plug/nic-hotplug/nic-hotplug-test.yml
@@ -145,7 +145,7 @@ jobs:
   cleanup: false
   # Set missing key as empty to allow using default values
   defaultMissingKeysWithZero: true
-  beforeCleanup: "../../config/scripts/wrapper.sh check_nic_hotplug {{ $jobCounterLabelKey }} {{ $jobCounterLabelValue }} {{ $nsName }} {{ $nicCount }} {{ .privateKey }} {{ .vmUser }} true {{ .runTimestamp }} {{ .resultsPath }}/{{ .runTimestamp }}/iteration-{{ .counter }}"
+  beforeCleanup: "../../config/scripts/wrapper.sh check_nic_hotplug {{ $jobCounterLabelKey }} {{ $jobCounterLabelValue }} {{ $nsName }} {{ $nicCount }} {{ .privateKey }} {{ .vmUser }} true {{ .resultsPath }}/{{ .runTimestamp }}/iteration-{{ .counter }}"
   objects:
   - objectTemplate: templates/secret_ssh_public.yml
     runOnce: true


### PR DESCRIPTION
## Summary

- Remove run-scoped `cnv-scenarios.io/run` label filtering from `check_nic_hotplug` validation
- Simplify positional arg handling (remove arg8/arg9 overloading)
- Update caller in `nic-hotplug-test.yml` to match new argument signature

Fixes #40

## Changes

| File | What changed |
|------|-------------|
| `check.sh` | `check_nic_hotplug`: removed `nncp_run_id` variable and compound label construction; use static `test-type=nic-hotplug-simple` / `test-type=nic-hotplug-vlan` labels directly; `results_dir` is now simply arg 8 |
| `nic-hotplug-test.yml` | Dropped `{{ .runTimestamp }}` from `beforeCleanup` args so `results_dir` receives the correct path |

## Code Review

**Files reviewed:** 4 (check.sh, nic-hotplug-test.yml, NNCP templates)
**Verdict:** APPROVED WITH SUGGESTIONS

### Key review findings addressed

- **FIXED**: Caller in `nic-hotplug-test.yml` updated to drop `{{ .runTimestamp }}` arg. Without this fix, `results_dir` would silently receive the timestamp string instead of the actual results path.
- **NOTED**: NNCP templates still carry `cnv-scenarios.io/run` label in metadata - kept for now as it's useful for manual debugging even if not queried by validation.
- **NOTED**: Removing run-scoped filtering means concurrent runs share NNCP counts. Concurrent nic-hotplug runs on the same cluster are not a supported scenario.

### Security check
No issues. Label selectors are hardcoded strings (no variable interpolation from untrusted input). `oc` output sanitized through `wc -l` / `jq` / `tr` consistently.

## Test plan

- [x] Tested single-run nic-hotplug validation - NNCPs discovered and status checked correctly
- [ ] Reviewer: confirm no callers pass 9 args to `check_nic_hotplug` outside of `nic-hotplug-test.yml`